### PR TITLE
[GHP-3714] Add support for max tasks per second

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,27 @@ A call to `worker.start` will take over the current process and will keep it unn
 or `INT` signal is received. By only registering a subset of your workflows/activities with a given
 worker you can split processing across as many workers as you need.
 
+## Worker Options
 
+- `task_queues`: hash (optional)
+
+This field let you customize the behavior per `task_queue`. Currently it's supporting only `task_queue_activities_per_second`.
+```rb
+worker = Worker.new(
+  task_queues: {
+    "30_rps" => { task_queue_activities_per_second: 30 },
+    "default" => { task_queue_activities_per_second: 100_000 }
+  }
+)
+
+# in your activity
+class ActivityA < Temporal::Activity
+  task_queue "30_rps"
+end
+```
+
+This will rate limit the number of `ActivityA` executions that can be started per second.
+	
 ## Starting a workflow
 
 All communication is handled via Temporal service, so in order to start a workflow you need to send

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -259,6 +259,9 @@ module Temporal
           namespace: namespace,
           task_queue: Temporalio::Api::TaskQueue::V1::TaskQueue.new(
             name: task_queue
+          ),
+          task_queue_metadata: Temporalio::Api::TaskQueue::V1::TaskQueueMetadata.new(
+            max_tasks_per_second: Google::Protobuf::DoubleValue.new(value: max_tasks_per_second)
           )
         )
 


### PR DESCRIPTION
## context

Worker initialization can now specify task queues and their `task_queue_activities_per_second`. 
This `task_queue_activities_per_second` is a way for Temporal server to rate limit the number of task executions that can be started per second per task queue.
This follow the Go SDK's https://docs.temporal.io/dev-guide/go/foundations#taskqueueactivitiespersecond
