### PR TITLE
Make the SDK be more configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+Expose two new configurations
+  - `client_config`: define the configurations for the workflow client
+  - `payload_converters_options`: define the configuration for the payload converters
+
 ## 0.1.1
 Allows signals to be processed within the first workflow task.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :development, :test do
+  gem 'pry-byebug'
+end

--- a/README.md
+++ b/README.md
@@ -178,6 +178,43 @@ Temporal.configure do |config|
 end
 ```
 
+## Using gRPC client configurations
+
+The SDK exposes an interface for us to customize the configuration for the gRPC client. For the full list of supported configurations, please refer to [original gRPC gem](https://github.com/grpc/grpc/blob/a04188b29f6f3165e54cff9e9586ab570421a6b0/src/ruby/lib/grpc/generic/client_stub.rb#L98)
+
+```ruby
+Temporal.configure do |config|
+  config.client_config = {
+    channel_args: {
+      ::GRPC::Core::Channel::SSL_TARGET => ENV["TEMPORAL_SERVER_NAME"]
+    }
+    # more configs for the client go here
+  }
+end
+```
+
+## Using payload converters configurations
+
+The SDK exposes an interface for us to customize the configuration for the payload converters. To understand more about Temporal data conversion, please to [the official document](https://docs.temporal.io/dataconversion)
+
+The SDK supports four types of data encoding:
+  - `json/plain`
+  - `binary/plain`
+  - `binary/null`
+  - `json/protobuf`
+
+```ruby
+Temporal.configure do |config|
+  config.payload_converters_options = {
+    'json/plain' => {
+      circular: true
+      # more configs for JSON converter go here
+    }
+   # more configs for other converter go here
+  }
+end
+```
+
 ## Workflows
 
 A workflow is defined using pure Ruby code, however it should contain only a high-level
@@ -366,7 +403,7 @@ end
 ```
 
 This will rate limit the number of `ActivityA` executions that can be started per second.
-	
+
 ## Starting a workflow
 
 All communication is handled via Temporal service, so in order to start a workflow you need to send

--- a/lib/temporal/connection.rb
+++ b/lib/temporal/connection.rb
@@ -12,8 +12,9 @@ module Temporal
       port = configuration.port
       credentials = configuration.credentials
       identity = configuration.identity
+      client_config = configuration.client_config
 
-      connection_class.new(host, port, identity, credentials)
+      connection_class.new(host, port, identity, credentials, client_config)
     end
   end
 end

--- a/lib/temporal/connection/converter/payload/base.rb
+++ b/lib/temporal/connection/converter/payload/base.rb
@@ -1,0 +1,29 @@
+module Temporal
+  module Connection
+    module Converter
+      module Payload
+        class Base
+          def initialize(options = {})
+            @options = options
+          end
+
+          def encoding
+            raise NotImplementedError
+          end
+
+          def from_payload(__payload)
+            raise NotImplementedError
+          end
+
+          def to_payload(_payload)
+            raise NotImplementedError
+          end
+
+          private
+
+            attr_reader :options
+        end
+      end
+    end
+  end
+end

--- a/lib/temporal/connection/converter/payload/base.rb
+++ b/lib/temporal/connection/converter/payload/base.rb
@@ -11,7 +11,7 @@ module Temporal
             raise NotImplementedError
           end
 
-          def from_payload(__payload)
+          def from_payload(_payload)
             raise NotImplementedError
           end
 

--- a/lib/temporal/connection/converter/payload/bytes.rb
+++ b/lib/temporal/connection/converter/payload/bytes.rb
@@ -1,10 +1,11 @@
 require 'temporal/json'
+require_relative 'base'
 
 module Temporal
   module Connection
     module Converter
       module Payload
-        class Bytes
+        class Bytes < Base
           ENCODING = 'binary/plain'.freeze
 
           def encoding

--- a/lib/temporal/connection/converter/payload/json.rb
+++ b/lib/temporal/connection/converter/payload/json.rb
@@ -1,10 +1,11 @@
 require 'temporal/json'
+require_relative 'base'
 
 module Temporal
   module Connection
     module Converter
       module Payload
-        class JSON
+        class JSON < Base
           ENCODING = 'json/plain'.freeze
 
           def encoding
@@ -12,13 +13,13 @@ module Temporal
           end
 
           def from_payload(payload)
-            Temporal::JSON.deserialize(payload.data)
+            Temporal::JSON.deserialize(payload.data, options)
           end
 
           def to_payload(data)
             Temporalio::Api::Common::V1::Payload.new(
               metadata: { 'encoding' => ENCODING },
-              data: Temporal::JSON.serialize(data).b
+              data: Temporal::JSON.serialize(data, options).b
             )
           end
         end

--- a/lib/temporal/connection/converter/payload/nil.rb
+++ b/lib/temporal/connection/converter/payload/nil.rb
@@ -1,8 +1,10 @@
+require_relative 'base'
+
 module Temporal
   module Connection
     module Converter
       module Payload
-        class Nil
+        class Nil < Base
           ENCODING = 'binary/null'.freeze
 
           def encoding

--- a/lib/temporal/connection/converter/payload/proto_json.rb
+++ b/lib/temporal/connection/converter/payload/proto_json.rb
@@ -1,10 +1,11 @@
 require 'temporal/json'
+require_relative 'base'
 
 module Temporal
   module Connection
     module Converter
       module Payload
-        class ProtoJSON
+        class ProtoJSON < Base
           ENCODING = 'json/protobuf'.freeze
 
           def encoding

--- a/lib/temporal/json.rb
+++ b/lib/temporal/json.rb
@@ -9,12 +9,12 @@ module Temporal
       float_precision: 0
     }.freeze
 
-    def self.serialize(value)
-      Oj.dump(value, OJ_OPTIONS)
+    def self.serialize(value, options = {})
+      Oj.dump(value, OJ_OPTIONS.merge(options))
     end
 
-    def self.deserialize(value)
-      Oj.load(value.to_s, OJ_OPTIONS)
+    def self.deserialize(value, options = {})
+      Oj.load(value.to_s, OJ_OPTIONS.merge(options))
     end
   end
 end

--- a/lib/temporal/version.rb
+++ b/lib/temporal/version.rb
@@ -1,3 +1,3 @@
 module Temporal
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/unit/lib/temporal/configuration_spec.rb
+++ b/spec/unit/lib/temporal/configuration_spec.rb
@@ -51,15 +51,22 @@ describe Temporal::Configuration do
   end
 
   describe '#for_connection' do
-    let (:new_identity) { 'new_identity' }
+    let(:new_identity) { 'new_identity' }
+    let(:client_config) { { channel_args: { 'foo' => 'again' } } }
+    let(:expected_client_config) { Temporal::Configuration::GRPCConfig.new(client_config) }
 
-    it 'default identity' do
+    it 'default identity and client_config' do
       expect(subject.for_connection).to have_attributes(identity: "#{Process.pid}@#{`hostname`}")
     end
 
     it 'override identity' do
       subject.identity = new_identity
       expect(subject.for_connection).to have_attributes(identity: new_identity)
+    end
+
+    it 'override client_config' do
+      subject.client_config = client_config
+      expect(subject.for_connection).to have_attributes(client_config: expected_client_config)
     end
   end
 end

--- a/spec/unit/lib/temporal/connection/converter/payload/json_spec.rb
+++ b/spec/unit/lib/temporal/connection/converter/payload/json_spec.rb
@@ -1,20 +1,35 @@
 require 'temporal/connection/converter/payload/json'
 
 describe Temporal::Connection::Converter::Payload::JSON do
-  subject { described_class.new }
+  subject { described_class.new(options) }
 
   describe 'round trip' do
-    it 'safely handles non-ASCII encodable UTF characters' do
-      input = { 'one' => 'one', two: :two, ':three' => '☻' }
+    context 'without custom options' do
+      let(:options) { {} }
 
-      expect(subject.from_payload(subject.to_payload(input))).to eq(input)
+      it 'safely handles non-ASCII encodable UTF characters' do
+        input = { 'one' => 'one', two: :two, ':three' => '☻' }
+
+        expect(subject.from_payload(subject.to_payload(input))).to eq(input)
+      end
+
+      it 'handles floats without loss of precision' do
+        input = { 'a_float' => 1626122510001.305986623 }
+
+        result = subject.from_payload(subject.to_payload(input))['a_float']
+        expect(result).to be_within(1e-8).of(input['a_float'])
+      end
     end
 
-    it 'handles floats without loss of precision' do
-      input = { 'a_float' => 1626122510001.305986623 }
-      result = subject.from_payload(subject.to_payload(input))['a_float']
-      expect(result).to be_within(1e-8).of(input['a_float'])
-    end
+    context 'with custom options' do
+      let(:options) { { circular: true } }
 
+      it 'safely handles circular references' do
+        input = []
+        input << [input]
+
+        expect(subject.from_payload(subject.to_payload(input))).to eq(input)
+      end
+    end
   end
 end

--- a/spec/unit/lib/temporal/connection_spec.rb
+++ b/spec/unit/lib/temporal/connection_spec.rb
@@ -10,6 +10,16 @@ describe Temporal::Connection do
     config
   end
 
+  context 'client_config' do
+    let(:client_config) { { channel_args: { 'foo' => 'again' } } }
+    let(:expected_client_config) { Temporal::Configuration::GRPCConfig.new(client_config) }
+
+    it 'overrides' do
+      config.client_config = client_config
+      expect(subject.send(:client_config)).to eq(expected_client_config)
+    end
+  end
+
   context 'identity' do
     let(:identity) { 'my_identity' }
     it 'overrides' do


### PR DESCRIPTION
# background

https://kaligo.atlassian.net/browse/GHP-3713

# design

Expose two new configurations for the SDK:
  - `client_config`: define the configurations for the workflow client
  - `payload_converters_options`:  define the configuration for the payload converters

**Sample configurations**

```ruby
Temporal.configure do |config|
  config.host = ENV.fetch("TEMPORAL_HOST", "localhost")
  config.port = Integer(ENV.fetch("TEMPORAL_PORT", 7233))
  config.namespace = ENV.fetch("TEMPORAL_NAMESPACE", "nydus")
  config.credentials = GRPC::Core::ChannelCredentials.new(root_cert, client_key, client_chain)
  
  # NEW CONFIGS

  config.client_config = {
    channel_args: {
      ::GRPC::Core::Channel::SSL_TARGET => ENV["TEMPORAL_SERVER_NAME"]
    }
    # more configs for the workflow client go here
  }
  config.payload_converters_options = {
    'json/plain' => {
      circular: true
      # more configs for JSON converter go here
    }
   # more configs for other converter go here
  }
end
```