### PR TITLE
Add statsd adapter support

### DIFF
--- a/lib/temporal/metrics_adapters/statsd.rb
+++ b/lib/temporal/metrics_adapters/statsd.rb
@@ -1,0 +1,19 @@
+module Temporal
+  module MetricsAdapters
+    class Statsd
+      def initialize(logger)
+        @logger = logger
+      end
+
+      [:count, :gauge, :timing].each do |method_name|
+        define_method(method_name) do |key, value, tags = {}|
+          logger.public_send(method_name, key, value, tags: tags)
+        end
+      end
+
+      private
+
+      attr_reader :logger
+    end
+  end
+end


### PR DESCRIPTION
`Temporal.metrics` is sending tags as a plain hash

```rb
metrics_tags = { namespace: namespace, task_queue: task_queue }.freeze
Temporal.metrics.timing(
  Temporal::MetricKeys::ACTIVITY_POLLER_TIME_SINCE_LAST_POLL,
  time_diff_ms,
  metrics_tags
)

def timing(key, time, tags = {})
  adapter.timing(key, time, tags)
end
```

This is not compatible with statsd, which expects the tags to be nested inside `tags` That means applications can't just use statsd implementation, one like https://github.com/DataDog/dogstatsd-ruby. They need to implement their own adapter that builds the tags before passing to the underlying client.

This PR adds an adapter that is compatible with statsd, so that applications can use that instead of writing their own.

```rb
statsd = Datadog::Statsd.new(...)
config.metrics_adapter = Temporal::MetricsAdapters::Statsd.new(statsd)
```